### PR TITLE
Remove links reachability validation.

### DIFF
--- a/src/main/kotlin/io/thecontext/ci/Runner.kt
+++ b/src/main/kotlin/io/thecontext/ci/Runner.kt
@@ -9,7 +9,6 @@ import io.thecontext.ci.input.TextReader
 import io.thecontext.ci.input.YamlReader
 import io.thecontext.ci.output.*
 import io.thecontext.ci.validation.*
-import okhttp3.OkHttpClient
 import java.io.File
 
 fun main(args: Array<String>) {
@@ -25,7 +24,7 @@ class Runner {
     private val inputFilesLocator by lazy { InputFilesLocator.Impl(ioScheduler) }
     private val inputReader by lazy { InputReader.Impl(yamlReader, textReader, ioScheduler) }
 
-    private val urlValidator by lazy { UrlValidator(OkHttpClient(), ioScheduler) }
+    private val urlValidator by lazy { UrlValidator(ioScheduler) }
     private val podcastValidator by lazy { PodcastValidator(urlValidator) }
     private val episodeValidator by lazy { EpisodeValidator(urlValidator) }
 

--- a/src/main/kotlin/io/thecontext/ci/validation/UrlValidator.kt
+++ b/src/main/kotlin/io/thecontext/ci/validation/UrlValidator.kt
@@ -3,35 +3,17 @@ package io.thecontext.ci.validation
 import io.reactivex.Scheduler
 import io.reactivex.Single
 import okhttp3.HttpUrl
-import okhttp3.OkHttpClient
-import okhttp3.Request
 
 class UrlValidator(
-        private val httpClient: OkHttpClient,
         private val ioScheduler: Scheduler
 ) : Validator<String> {
 
     override fun validate(value: String) = Single
             .fromCallable {
-                val httpUrl = HttpUrl.parse(value)
-
-                if (httpUrl == null) {
+                if (HttpUrl.parse(value) == null) {
                     ValidationResult.Failure("URL [$value] has invalid format.")
                 } else {
-                    val request = Request.Builder()
-                            .url(httpUrl)
-                            .head()
-                            .build()
-
-                    val response = httpClient
-                            .newCall(request)
-                            .execute()
-
-                    if (response.isSuccessful) {
-                        ValidationResult.Success
-                    } else {
-                        ValidationResult.Failure("URL [$value] returns [${response.code()}].")
-                    }
+                    ValidationResult.Success
                 }
             }
             .subscribeOn(ioScheduler)

--- a/src/test/kotlin/io/thecontext/ci/validation/UrlValidatorSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/validation/UrlValidatorSpec.kt
@@ -4,22 +4,21 @@ import com.greghaskins.spectrum.Spectrum
 import com.greghaskins.spectrum.dsl.specification.Specification.*
 import io.reactivex.schedulers.Schedulers
 import io.thecontext.ci.memoized
-import okhttp3.*
 import org.junit.runner.RunWith
 
 @RunWith(Spectrum::class)
 class UrlValidatorSpec {
     init {
+        val validator by memoized { UrlValidator(Schedulers.trampoline()) }
+
         describe("non-HTTP URI") {
 
             listOf("schema://localhost", "asset://localhost", "file://localhost").forEach { uri ->
 
                 context("uri [$uri]") {
 
-                    val env by memoized { Environment() }
-
                     it("emits result as failure") {
-                        env.validator.validate(uri)
+                        validator.validate(uri)
                                 .test()
                                 .assertValue { it is ValidationResult.Failure }
                     }
@@ -33,56 +32,13 @@ class UrlValidatorSpec {
 
                 context("url [$url]") {
 
-                    context("link is reachable") {
-
-                        val env by memoized { Environment(supportedUrls = listOf(url)) }
-
-                        it("emits result as success") {
-                            env.validator.validate(url)
-                                    .test()
-                                    .assertValue(ValidationResult.Success)
-                        }
-                    }
-
-                    context("link is unreachable") {
-
-                        val env by memoized { Environment(supportedUrls = emptyList()) }
-
-                        it("emits link as not valid") {
-                            env.validator.validate(url)
-                                    .test()
-                                    .assertValue { it is ValidationResult.Failure }
-                        }
+                    it("emits result as success") {
+                        validator.validate(url)
+                                .test()
+                                .assertValue(ValidationResult.Success)
                     }
                 }
             }
-        }
-    }
-
-    private class Environment(supportedUrls: List<String> = emptyList()) {
-        private val httpClient = OkHttpClient.Builder()
-                .addInterceptor(ProxyInterceptor(supportedUrls))
-                .build()
-
-        val validator = UrlValidator(httpClient, Schedulers.trampoline())
-    }
-
-    private class ProxyInterceptor(
-            private val supportedUrls: List<String>
-    ) : Interceptor {
-
-        override fun intercept(chain: Interceptor.Chain): Response {
-            val request = chain.request()
-
-            val response = Response.Builder()
-                    .request(request)
-                    .protocol(Protocol.HTTP_2)
-                    .message("It works!")
-                    .code(if (supportedUrls.map { HttpUrl.parse(it) }.contains(request.url())) 200 else 500)
-                    .body(ResponseBody.create(MediaType.parse("mime"), "content"))
-                    .build()
-
-            return response
         }
     }
 }


### PR DESCRIPTION
Neat idea, but have some issues in practice.

* Too long to execute even on simple datasets.
* Services tend to ban too fast requests (OH HAI GITHUB).
* It is inevitable that links will stale over time failing the validation.