### PR TITLE
guid  must be specified in episode's .yml file

### DIFF
--- a/src/main/kotlin/io/thecontext/ci/Runner.kt
+++ b/src/main/kotlin/io/thecontext/ci/Runner.kt
@@ -49,8 +49,9 @@ class Runner {
                 .switchMapSingle { inputResult ->
                     val podcast = PodcastValidator(urlValidator, inputResult.people).validate(inputResult.podcast)
                     val episodes = inputResult.episodes.map { EpisodeValidator(urlValidator, inputResult.people).validate(it) }
+                    val episodeList = EpisodeListValidator(ioScheduler).validate(inputResult.episodes)
 
-                    Single.merge(episodes.plus(podcast)).toList().map { it.merge() }
+                    Single.merge(episodes.plus(podcast).plus(episodeList)).toList().map { it.merge() }
                 }
 
         val output = validation

--- a/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
@@ -46,7 +46,7 @@ interface PodcastXmlFormatter {
                             "build_date" to LocalDate.now().toRfc2822(),
                             "episodes" to episodes.map { (episode, episodeMarkdown) ->
                                 mapOf(
-                                        "guid" to episode.guid,
+                                        "id" to episode.id,
                                         "title" to episode.title,
                                         "description" to episode.description,
                                         "date" to episode.date.toDate().toRfc2822(),

--- a/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
@@ -46,6 +46,7 @@ interface PodcastXmlFormatter {
                             "build_date" to LocalDate.now().toRfc2822(),
                             "episodes" to episodes.map { (episode, episodeMarkdown) ->
                                 mapOf(
+                                        "guid" to episode.guid,
                                         "title" to episode.title,
                                         "description" to episode.description,
                                         "date" to episode.date.toDate().toRfc2822(),

--- a/src/main/kotlin/io/thecontext/ci/validation/EpisodeListValidator.kt
+++ b/src/main/kotlin/io/thecontext/ci/validation/EpisodeListValidator.kt
@@ -1,0 +1,39 @@
+package io.thecontext.ci.validation
+
+import io.reactivex.Scheduler
+import io.reactivex.Single
+import io.thecontext.ci.value.Episode
+
+class EpisodeListValidator(
+        private val ioScheduler: Scheduler
+) : Validator<List<Episode>> {
+
+    private val Episode.readableIdForError
+        get() = title
+
+    override fun validate(value: List<Episode>): Single<ValidationResult> = Single.fromCallable {
+        val uniqueIds = HashMap<String, Episode>()
+        val errorMessage = StringBuilder()
+        value.forEach { episode ->
+            val episodeWithSameId: Episode? = uniqueIds.putIfAbsent(episode.id, episode)
+            if (episodeWithSameId != null) {
+                if (errorMessage.isNotEmpty())
+                    errorMessage.appendln()
+
+                errorMessage.append("Error: Episode id must be unique but id = \"")
+                        .append(episode.id)
+                        .append("\" is used for \"")
+                        .append(episode.readableIdForError)
+                        .append("\" and \"")
+                        .append(episodeWithSameId.readableIdForError)
+                        .append('\"')
+            }
+        }
+
+        if (errorMessage.isEmpty()) {
+            ValidationResult.Success
+        } else {
+            ValidationResult.Failure(errorMessage.toString())
+        }
+    }.subscribeOn(ioScheduler)
+}

--- a/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
+++ b/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
@@ -45,15 +45,11 @@ class EpisodeValidator(
                 }
 
         val guidResult = Single.fromCallable {
-            if (value.guid.isEmpty()) {
-                ValidationResult.Failure("$episodeIdentifierForError: guid is empty")
+            if (value.guid.isBlank()) {
+                ValidationResult.Failure("$episodeIdentifierForError: guid is blank")
+            } else {
+                ValidationResult.Success
             }
-
-            if (value.guid.contains(' ')) {
-                ValidationResult.Failure("$episodeIdentifierForError: guid contains white space")
-            }
-
-            ValidationResult.Success
         }
 
         val numberResult = Single.fromCallable {

--- a/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
+++ b/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
@@ -16,6 +16,7 @@ class EpisodeValidator(
     }
 
     override fun validate(value: Episode): Single<ValidationResult> {
+        val episodeIdentifierForError = value.title
         val urlResults = emptyList<String>()
                 .plus(value.url)
                 .plus(value.discussionUrl)
@@ -28,20 +29,20 @@ class EpisodeValidator(
                 .map { personId ->
                     Single.fromCallable {
                         if (people.find { it.id == personId } == null) {
-                            ValidationResult.Failure("Person [$personId] is not defined.")
+                            ValidationResult.Failure("$episodeIdentifierForError: Person [$personId] is not defined.")
                         } else {
                             ValidationResult.Success
                         }
                     }
                 }
 
-        val uuidResult = Single.fromCallable {
-            if (value.guid.isBlank()){
-                ValidationResult.Failure("guid is blank")
+        val guidResult = Single.fromCallable {
+            if (value.guid.isEmpty()){
+                ValidationResult.Failure("$episodeIdentifierForError: guid is empty")
             }
 
             if (value.guid.contains(' ')){
-                ValidationResult.Failure("guid contains white space")
+                ValidationResult.Failure("$episodeIdentifierForError: guid contains white space")
             }
 
             ValidationResult.Success
@@ -49,7 +50,7 @@ class EpisodeValidator(
 
         val numberResult = Single.fromCallable {
             if (value.number < 0) {
-                ValidationResult.Failure("Episode number is negative.")
+                ValidationResult.Failure("$episodeIdentifierForError: Episode number is negative.")
             } else {
                 ValidationResult.Success
             }
@@ -61,13 +62,13 @@ class EpisodeValidator(
 
                 ValidationResult.Success
             } catch (e: DateTimeParseException) {
-                ValidationResult.Failure("Episode date is in wrong format. Should be YYYY-MM-DD.")
+                ValidationResult.Failure("$episodeIdentifierForError: Episode date is in wrong format. Should be YYYY-MM-DD.")
             }
         }
 
         val fileLengthResult = Single.fromCallable {
             if (value.file.length < 0) {
-                ValidationResult.Failure("File length is negative.")
+                ValidationResult.Failure("$episodeIdentifierForError: File length is negative.")
             } else {
                 ValidationResult.Success
             }
@@ -75,14 +76,14 @@ class EpisodeValidator(
 
         val descriptionResult = Single.fromCallable {
             if (value.description.length > MAXIMUM_DESCRIPTION_LENGTH) {
-                ValidationResult.Failure("Description length is [${value.description.length}] symbols but should less than [${MAXIMUM_DESCRIPTION_LENGTH}].")
+                ValidationResult.Failure("$episodeIdentifierForError: Description length is [${value.description.length}] symbols but should less than [${MAXIMUM_DESCRIPTION_LENGTH}].")
             } else {
                 ValidationResult.Success
             }
         }
 
         return Single
-                .merge(urlResults + peopleResults + listOf(uuidResult, numberResult, dateResult, fileLengthResult, descriptionResult))
+                .merge(urlResults + peopleResults + listOf(guidResult, numberResult, dateResult, fileLengthResult, descriptionResult))
                 .toList()
                 .map { it.merge() }
     }

--- a/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
+++ b/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
@@ -44,9 +44,9 @@ class EpisodeValidator(
                     }
                 }
 
-        val guidResult = Single.fromCallable {
-            if (value.guid.isBlank()) {
-                ValidationResult.Failure("$episodeIdentifierForError: guid is blank")
+        val idResult = Single.fromCallable {
+            if (value.id.isBlank()) {
+                ValidationResult.Failure("$episodeIdentifierForError: id is blank")
             } else {
                 ValidationResult.Success
             }
@@ -87,7 +87,7 @@ class EpisodeValidator(
         }
 
         return Single
-                .merge(urlResults + peopleResults + listOf(guidResult, numberResult, dateResult, fileLengthResult, descriptionResult))
+                .merge(urlResults + peopleResults + listOf(idResult, numberResult, dateResult, fileLengthResult, descriptionResult))
                 .toList()
                 .map { it.merge() }
     }

--- a/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
+++ b/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
@@ -35,6 +35,18 @@ class EpisodeValidator(
                     }
                 }
 
+        val uuidResult = Single.fromCallable {
+            if (value.guid.isBlank()){
+                ValidationResult.Failure("guid is blank")
+            }
+
+            if (value.guid.contains(' ')){
+                ValidationResult.Failure("guid contains white space")
+            }
+
+            ValidationResult.Success
+        }
+
         val numberResult = Single.fromCallable {
             if (value.number < 0) {
                 ValidationResult.Failure("Episode number is negative.")
@@ -70,7 +82,7 @@ class EpisodeValidator(
         }
 
         return Single
-                .merge(urlResults + peopleResults + listOf(numberResult, dateResult, fileLengthResult, descriptionResult))
+                .merge(urlResults + peopleResults + listOf(uuidResult, numberResult, dateResult, fileLengthResult, descriptionResult))
                 .toList()
                 .map { it.merge() }
     }

--- a/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
+++ b/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
@@ -21,7 +21,15 @@ class EpisodeValidator(
                 .plus(value.url)
                 .plus(value.discussionUrl)
                 .plus(value.file.url)
-                .map { urlValidator.validate(it) }
+                .map {
+                    urlValidator.validate(it)
+                            .map {
+                                when (it) {
+                                    ValidationResult.Success -> it
+                                    is ValidationResult.Failure -> it.copy("$episodeIdentifierForError: ${it.message}")
+                                }
+                            }
+                }
 
         val peopleResults = emptyList<String>()
                 .plus(value.people.hostIds)
@@ -37,11 +45,11 @@ class EpisodeValidator(
                 }
 
         val guidResult = Single.fromCallable {
-            if (value.guid.isEmpty()){
+            if (value.guid.isEmpty()) {
                 ValidationResult.Failure("$episodeIdentifierForError: guid is empty")
             }
 
-            if (value.guid.contains(' ')){
+            if (value.guid.contains(' ')) {
                 ValidationResult.Failure("$episodeIdentifierForError: guid contains white space")
             }
 

--- a/src/main/kotlin/io/thecontext/ci/validation/PodcastValidator.kt
+++ b/src/main/kotlin/io/thecontext/ci/validation/PodcastValidator.kt
@@ -24,7 +24,7 @@ class PodcastValidator(
                 .map { personId ->
                     Single.fromCallable {
                         if (people.find { it.id == personId } == null) {
-                            ValidationResult.Failure("Podcast Authors or Owner: Person [$personId] is not defined.")
+                            ValidationResult.Failure("Podcast person [$personId] is not defined.")
                         } else {
                             ValidationResult.Success
                         }

--- a/src/main/kotlin/io/thecontext/ci/validation/PodcastValidator.kt
+++ b/src/main/kotlin/io/thecontext/ci/validation/PodcastValidator.kt
@@ -24,7 +24,7 @@ class PodcastValidator(
                 .map { personId ->
                     Single.fromCallable {
                         if (people.find { it.id == personId } == null) {
-                            ValidationResult.Failure("Person [$personId] is not defined.")
+                            ValidationResult.Failure("Podcast Authors or Owner: Person [$personId] is not defined.")
                         } else {
                             ValidationResult.Success
                         }
@@ -33,7 +33,7 @@ class PodcastValidator(
 
         val descriptionResult = Single.fromCallable {
             if (value.description.length > MAXIMUM_DESCRIPTION_LENGTH) {
-                ValidationResult.Failure("Description length is [${value.description.length}] symbols but should less than [$MAXIMUM_DESCRIPTION_LENGTH].")
+                ValidationResult.Failure("Podcast description length is [${value.description.length}] symbols but should less than [$MAXIMUM_DESCRIPTION_LENGTH].")
             } else {
                 ValidationResult.Success
             }

--- a/src/main/kotlin/io/thecontext/ci/value/Episode.kt
+++ b/src/main/kotlin/io/thecontext/ci/value/Episode.kt
@@ -6,8 +6,8 @@ data class Episode(
 
         val slug: String = "",
 
-        @JsonProperty("guid")
-        val guid: String,
+        @JsonProperty("id")
+        val id: String,
 
         @JsonProperty("number")
         val number: Int,

--- a/src/main/kotlin/io/thecontext/ci/value/Episode.kt
+++ b/src/main/kotlin/io/thecontext/ci/value/Episode.kt
@@ -1,10 +1,14 @@
 package io.thecontext.ci.value
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.File
 
 data class Episode(
 
         val slug: String = "",
+
+        @JsonProperty("guid")
+        val guid : String,
 
         @JsonProperty("number")
         val number: Int,

--- a/src/main/kotlin/io/thecontext/ci/value/Episode.kt
+++ b/src/main/kotlin/io/thecontext/ci/value/Episode.kt
@@ -1,14 +1,13 @@
 package io.thecontext.ci.value
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import java.io.File
 
 data class Episode(
 
         val slug: String = "",
 
         @JsonProperty("guid")
-        val guid : String,
+        val guid: String,
 
         @JsonProperty("number")
         val number: Int,

--- a/src/main/resources/podcast.xml.mustache
+++ b/src/main/resources/podcast.xml.mustache
@@ -29,7 +29,7 @@
       <title>{{title}}</title>
       <description>{{description}}</description>
       <pubDate>{{date}}</pubDate>
-      <guid>{{file_url}}</guid>
+      <guid>{{guid}}</guid>
       <link>{{url}}</link>
       <enclosure url="{{file_url}}" length="{{file_length}}" type="audio/mpeg"/>
       <atom:link rel="replies" type="text/html" href="{{discussion_url}}"/>

--- a/src/main/resources/podcast.xml.mustache
+++ b/src/main/resources/podcast.xml.mustache
@@ -29,7 +29,7 @@
       <title>{{title}}</title>
       <description>{{description}}</description>
       <pubDate>{{date}}</pubDate>
-      <guid>{{guid}}</guid>
+      <guid>{{id}}</guid>
       <link>{{url}}</link>
       <enclosure url="{{file_url}}" length="{{file_length}}" type="audio/mpeg"/>
       <atom:link rel="replies" type="text/html" href="{{discussion_url}}"/>

--- a/src/test/kotlin/io/thecontext/ci/Data.kt
+++ b/src/test/kotlin/io/thecontext/ci/Data.kt
@@ -34,7 +34,7 @@ val testPodcast = Podcast(
 )
 
 val testEpisode = Episode(
-        guid = "thecontext/episode/42",
+        id = "thecontext/episode/42",
         number = 42,
         title = "Episode Title",
         description = "Episode Description",

--- a/src/test/kotlin/io/thecontext/ci/Data.kt
+++ b/src/test/kotlin/io/thecontext/ci/Data.kt
@@ -34,7 +34,7 @@ val testPodcast = Podcast(
 )
 
 val testEpisode = Episode(
-        guid = "TestEpisode",
+        guid = "thecontext/episode/42",
         number = 42,
         title = "Episode Title",
         description = "Episode Description",

--- a/src/test/kotlin/io/thecontext/ci/Data.kt
+++ b/src/test/kotlin/io/thecontext/ci/Data.kt
@@ -34,6 +34,7 @@ val testPodcast = Podcast(
 )
 
 val testEpisode = Episode(
+        guid = "TestEpisode",
         number = 42,
         title = "Episode Title",
         description = "Episode Description",

--- a/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
@@ -85,7 +85,7 @@ class YamlReaderSpec {
             val episode = testEpisode.copy(notesMarkdown = "")
             val episodeYaml =
                     """
-                    guid: ${episode.guid}
+                    id: ${episode.id}
                     number: ${episode.number}
                     title: ${episode.title}
                     description: ${episode.description}

--- a/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
@@ -85,6 +85,7 @@ class YamlReaderSpec {
             val episode = testEpisode.copy(notesMarkdown = "")
             val episodeYaml =
                     """
+                    guid: ${episode.guid}
                     number: ${episode.number}
                     title: ${episode.title}
                     description: ${episode.description}

--- a/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
@@ -53,7 +53,7 @@ class PodcastXmlFormatterSpec {
                           <title>${episode.title}</title>
                           <description>${episode.description}</description>
                           <pubDate>${episode.date.toDate().toRfc2822()}</pubDate>
-                          <guid>${episode.file.url}</guid>
+                          <guid>${episode.guid}</guid>
                           <link>${episode.url}</link>
                           <enclosure url="${episode.file.url}" length="${episode.file.length}" type="audio/mpeg"/>
                           <atom:link rel="replies" type="text/html" href="${episode.discussionUrl}"/>

--- a/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
@@ -53,7 +53,7 @@ class PodcastXmlFormatterSpec {
                           <title>${episode.title}</title>
                           <description>${episode.description}</description>
                           <pubDate>${episode.date.toDate().toRfc2822()}</pubDate>
-                          <guid>${episode.guid}</guid>
+                          <guid>${episode.id}</guid>
                           <link>${episode.url}</link>
                           <enclosure url="${episode.file.url}" length="${episode.file.length}" type="audio/mpeg"/>
                           <atom:link rel="replies" type="text/html" href="${episode.discussionUrl}"/>

--- a/src/test/kotlin/io/thecontext/ci/validation/EpisodeListValidatorSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/validation/EpisodeListValidatorSpec.kt
@@ -1,0 +1,65 @@
+package io.thecontext.ci.validation
+
+import com.greghaskins.spectrum.Spectrum
+import com.greghaskins.spectrum.dsl.specification.Specification.*
+import io.reactivex.schedulers.Schedulers
+import io.thecontext.ci.memoized
+import io.thecontext.ci.testEpisode
+import io.thecontext.ci.value.Episode
+import org.junit.runner.RunWith
+
+@RunWith(Spectrum::class)
+class EpisodeListValidatorSpec {
+    init {
+        val validator by memoized { EpisodeListValidator(Schedulers.trampoline()) }
+
+        context("list of episode with unique ids") {
+            val episodes = listOf(
+                    testEpisode.copy(
+                            id = "id1",
+                            title = "Episode 1"
+                    ),
+                    testEpisode.copy(
+                            id = "id2",
+                            title = "Episode 2"
+                    )
+            )
+            it("returns validation result successful") {
+                validator.validate(episodes)
+                        .test()
+                        .assertValue { it is ValidationResult.Success }
+            }
+        }
+
+        context("list of episode with same ids") {
+            val episodes = listOf(
+                    testEpisode.copy(
+                            id = "someID",
+                            title = "Episode 1"
+                    ),
+                    testEpisode.copy(
+                            id = "someID",
+                            title = "Episode 2"
+                    ),
+                    testEpisode,
+                    testEpisode.copy(
+                            id = "someID2",
+                            title = "Episode 3"
+                    ),
+                    testEpisode.copy(
+                            id = "someID2",
+                            title = "Episode 4"
+                    )
+            )
+            it("returns validation result failure") {
+                validator.validate(episodes)
+                        .test()
+                        .assertValue {
+                            it is ValidationResult.Failure
+                                    && it.message == "Error: Episode id must be unique but id = \"someID\" is used for \"Episode 2\" and \"Episode 1\"\n" +
+                                    "Error: Episode id must be unique but id = \"someID2\" is used for \"Episode 4\" and \"Episode 3\""
+                        }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/thecontext/ci/validation/EpisodeValidatorSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/validation/EpisodeValidatorSpec.kt
@@ -13,16 +13,16 @@ class EpisodeValidatorSpec {
     init {
         val env by memoized { Environment() }
 
-        context("guid validation failed") {
+        context("id validation failed") {
 
-            it("emits result as failure on empty guid") {
-                env.validator.validate(testEpisode.copy(guid = ""))
+            it("emits result as failure on empty id") {
+                env.validator.validate(testEpisode.copy(id = ""))
                         .test()
                         .assertValue { it is ValidationResult.Failure }
             }
 
-            it("emits result as failure on blank guid") {
-                env.validator.validate(testEpisode.copy(guid = " "))
+            it("emits result as failure on blank id") {
+                env.validator.validate(testEpisode.copy(id = " "))
                         .test()
                         .assertValue { it is ValidationResult.Failure }
             }

--- a/src/test/kotlin/io/thecontext/ci/validation/EpisodeValidatorSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/validation/EpisodeValidatorSpec.kt
@@ -14,9 +14,6 @@ class EpisodeValidatorSpec {
         val env by memoized { Environment() }
 
         context("guid validation failed") {
-            beforeEach {
-                env.urlValidator.result = ValidationResult.Failure("nope")
-            }
 
             it("emits result as failure on empty guid") {
                 env.validator.validate(testEpisode.copy(guid = ""))
@@ -24,14 +21,8 @@ class EpisodeValidatorSpec {
                         .assertValue { it is ValidationResult.Failure }
             }
 
-            it("emits result as failure on empty guid") {
+            it("emits result as failure on blank guid") {
                 env.validator.validate(testEpisode.copy(guid = " "))
-                        .test()
-                        .assertValue { it is ValidationResult.Failure }
-            }
-
-            it("emits result as failure on white space in guid") {
-                env.validator.validate(testEpisode.copy(guid = "u u i d"))
                         .test()
                         .assertValue { it is ValidationResult.Failure }
             }

--- a/src/test/kotlin/io/thecontext/ci/validation/EpisodeValidatorSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/validation/EpisodeValidatorSpec.kt
@@ -13,6 +13,30 @@ class EpisodeValidatorSpec {
     init {
         val env by memoized { Environment() }
 
+        context("guid validation failed") {
+            beforeEach {
+                env.urlValidator.result = ValidationResult.Failure("nope")
+            }
+
+            it("emits result as failure on empty guid") {
+                env.validator.validate(testEpisode.copy(guid = ""))
+                        .test()
+                        .assertValue { it is ValidationResult.Failure }
+            }
+
+            it("emits result as failure on empty guid") {
+                env.validator.validate(testEpisode.copy(guid = " "))
+                        .test()
+                        .assertValue { it is ValidationResult.Failure }
+            }
+
+            it("emits result as failure on white space in guid") {
+                env.validator.validate(testEpisode.copy(guid = "u u i d"))
+                        .test()
+                        .assertValue { it is ValidationResult.Failure }
+            }
+        }
+
         context("url validation failed") {
 
             beforeEach {


### PR DESCRIPTION
What I changed?
- `guid` must be specified in each episode in `.yml` file for each manually.
- Added `episode.title` to error messages of `EpisodeValidator` so that we know which episode caused the validation error.