### PR TITLE
Keep order of episodes while generating rss feed

### DIFF
--- a/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
@@ -26,7 +26,7 @@ interface PodcastXmlFormatter {
         }
 
         override fun format(podcast: Podcast, episodes: List<Episode>, people: List<Person>) = Single
-                .merge(episodes.map { episode -> episodeMarkdownFormatter.format(podcast, episode, people).map { episode to it } })
+                .concat(episodes.map { episode -> episodeMarkdownFormatter.format(podcast, episode, people).map { episode to it } })
                 .toList()
                 .map { episodes ->
                     val contents = mapOf(


### PR DESCRIPTION
Keeps the same order as episodes have been read while writing rss feed items.
This basically means that the order of the rss feed items are the same as the order of the episode folders in the file system which eventually means (if we follow our naming conventions properly): Episode 1 is the first item in the rss feed and the latest released item is at the bottom of the rss list.