### PR TITLE
Remove people from podcast XML.

### DIFF
--- a/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
@@ -55,8 +55,6 @@ interface PodcastXmlFormatter {
                                         "url" to episode.url,
                                         "discussion_url" to episode.discussionUrl,
                                         "duration" to episode.duration,
-                                        "hosts" to episode.people.hostIds.map { people.find(it) }.map { mapOf("name" to it.name) },
-                                        "guests" to episode.people.guestIds.map { people.find(it) }.map { mapOf("name" to it.name) },
                                         "summary" to markdownRenderer.renderHtml(episodeMarkdown).trim().prependIndent(" ".repeat(10))
                                 )
                             }

--- a/src/main/resources/podcast.xml.mustache
+++ b/src/main/resources/podcast.xml.mustache
@@ -34,16 +34,6 @@
       <enclosure url="{{file_url}}" length="{{file_length}}" type="audio/mpeg"/>
       <atom:link rel="replies" type="text/html" href="{{discussion_url}}"/>
       <itunes:duration>{{duration}}</itunes:duration>
-      {{#hosts}}
-      <atom:author>
-        <atom:name>{{name}}</atom:name>
-      </atom:author>
-      {{/hosts}}
-      {{#guests}}
-      <atom:contributor>
-        <atom:name>{{name}}</atom:name>
-      </atom:contributor>
-      {{/guests}}
       <content:encoded>
         <![CDATA[
 {{&summary}}

--- a/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
@@ -58,18 +58,6 @@ class PodcastXmlFormatterSpec {
                           <enclosure url="${episode.file.url}" length="${episode.file.length}" type="audio/mpeg"/>
                           <atom:link rel="replies" type="text/html" href="${episode.discussionUrl}"/>
                           <itunes:duration>${episode.duration}</itunes:duration>
-                          <atom:author>
-                            <atom:name>${people[0].name}</atom:name>
-                          </atom:author>
-                          <atom:author>
-                            <atom:name>${people[1].name}</atom:name>
-                          </atom:author>
-                          <atom:contributor>
-                            <atom:name>${people[0].name}</atom:name>
-                          </atom:contributor>
-                          <atom:contributor>
-                            <atom:name>${people[1].name}</atom:name>
-                          </atom:contributor>
                           <content:encoded>
                             <![CDATA[
                               ${env.markdownRenderer.renderResult}


### PR DESCRIPTION
The current feed has it but after examining a lot of different popular feeds and, more importantly, different players I can say that it is not used anywhere, at least not being shown to users.