### PR TITLE
Add content namespace to podcast XML.

### DIFF
--- a/src/main/resources/podcast.xml.mustache
+++ b/src/main/resources/podcast.xml.mustache
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>{{title}}</title>
     <description>{{description}}</description>

--- a/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
@@ -22,7 +22,7 @@ class PodcastXmlFormatterSpec {
             it("formats") {
                 val expected = """
                     <?xml version="1.0" encoding="utf-8"?>
-                    <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+                    <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
                       <channel>
                         <title>${podcast.title}</title>
                         <description>${podcast.description}</description>


### PR DESCRIPTION
Not sure namespaces are even used by anybody, but it will help to pass the validation.