### PR TITLE
Add support (and requirement) for podcast author email addresses.

### DIFF
--- a/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
@@ -41,7 +41,7 @@ interface PodcastXmlFormatter {
                             "category" to podcast.category,
                             "subcategory" to podcast.subcategory,
                             "keywords" to podcast.keywords.joinToString(separator = ","),
-                            "owners" to podcast.people.ownerIds.map { people.find(it) }.map { mapOf("name" to it.name) },
+                            "owners" to podcast.people.ownerIds.map { people.find(it) }.map { mapOf("name" to it.name, "email" to it.email) },
                             "authors" to podcast.people.authorIds.map { people.find(it) }.map { mapOf("name" to it.name) },
                             "build_date" to LocalDate.now().toRfc2822(),
                             "episodes" to preparedEpisodes.map { (episode, episodeMarkdown) ->

--- a/src/main/kotlin/io/thecontext/ci/validation/PodcastValidator.kt
+++ b/src/main/kotlin/io/thecontext/ci/validation/PodcastValidator.kt
@@ -31,6 +31,14 @@ class PodcastValidator(
                     }
                 }
 
+        val ownerResults = Single.fromCallable {
+            if (value.people.ownerIds.any { ownerId -> people.find { it.id == ownerId }?.email == null }) {
+                ValidationResult.Failure("Podcast owners should have email address.")
+            } else {
+                ValidationResult.Success
+            }
+        }
+
         val descriptionResult = Single.fromCallable {
             if (value.description.length > MAXIMUM_DESCRIPTION_LENGTH) {
                 ValidationResult.Failure("Podcast description length is [${value.description.length}] symbols but should less than [$MAXIMUM_DESCRIPTION_LENGTH].")
@@ -40,7 +48,7 @@ class PodcastValidator(
         }
 
         return Single
-                .merge(urlResults + peopleResults + listOf(descriptionResult))
+                .merge(urlResults + peopleResults + ownerResults + listOf(descriptionResult))
                 .toList()
                 .map { it.merge() }
     }

--- a/src/main/kotlin/io/thecontext/ci/value/Person.kt
+++ b/src/main/kotlin/io/thecontext/ci/value/Person.kt
@@ -10,6 +10,9 @@ data class Person(
         @JsonProperty("name")
         val name: String,
 
+        @JsonProperty("email")
+        val email: String?,
+
         @JsonProperty("twitter")
         val twitter: String?,
 

--- a/src/main/resources/podcast.xml.mustache
+++ b/src/main/resources/podcast.xml.mustache
@@ -17,6 +17,7 @@
     {{#owners}}
     <itunes:owner>
       <itunes:name>{{name}}</itunes:name>
+      <itunes:email>{{email}}</itunes:email>
     </itunes:owner>
     {{/owners}}
     {{#authors}}

--- a/src/test/kotlin/io/thecontext/ci/Data.kt
+++ b/src/test/kotlin/io/thecontext/ci/Data.kt
@@ -7,6 +7,7 @@ import io.thecontext.ci.value.Podcast
 val testPerson = Person(
         id = "Person ID",
         name = "Person Name",
+        email = "person@mail.com",
         twitter = "Twitter ID",
         github = "GitHub ID",
         site = "localhost"

--- a/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
@@ -30,6 +30,7 @@ class YamlReaderSpec {
                     """
                     - id: ${person.id}
                       name: ${person.name}
+                      email: ${person.email}
                       twitter: ${person.twitter}
                       github: ${person.github}
                       website: ${person.site}

--- a/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
@@ -39,9 +39,11 @@ class PodcastXmlFormatterSpec {
                         <itunes:keywords>${podcast.keywords.joinToString(separator = ",")}</itunes:keywords>
                         <itunes:owner>
                           <itunes:name>${people[0].name}</itunes:name>
+                          <itunes:email>${people[0].email}</itunes:email>
                         </itunes:owner>
                         <itunes:owner>
                           <itunes:name>${people[1].name}</itunes:name>
+                          <itunes:email>${people[1].email}</itunes:email>
                         </itunes:owner>
                         <atom:author>
                           <atom:name>${people[0].name}</atom:name>

--- a/src/test/kotlin/io/thecontext/ci/output/WebsiteFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/WebsiteFormatterSpec.kt
@@ -19,7 +19,7 @@ class WebsiteFormatterSpec {
                 ioScheduler = Schedulers.trampoline()
         )
 
-        val host1 = Person(
+        val host1 = testPerson.copy(
                 id = "host1",
                 github = "github1",
                 name = "Person 1",
@@ -27,7 +27,7 @@ class WebsiteFormatterSpec {
                 twitter = "person1"
         )
 
-        val host2 = Person(
+        val host2 = testPerson.copy(
                 id = "host2",
                 github = "github2",
                 name = "Person 2",
@@ -35,7 +35,7 @@ class WebsiteFormatterSpec {
                 twitter = "person2"
         )
 
-        val guest1 = Person(
+        val guest1 = testPerson.copy(
                 id = "guest1",
                 github = "github3",
                 name = "Person 3",
@@ -43,7 +43,7 @@ class WebsiteFormatterSpec {
                 twitter = "person3"
         )
 
-        val guest2 = Person(
+        val guest2 = testPerson.copy(
                 id = "guest2",
                 github = "github4",
                 name = "Person 4",

--- a/src/test/kotlin/io/thecontext/ci/validation/PodcastValidatorSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/validation/PodcastValidatorSpec.kt
@@ -13,6 +13,15 @@ class PodcastValidatorSpec {
     init {
         val env by memoized { Environment() }
 
+        context("value is valid") {
+
+            it("emits result as success") {
+                env.validator.validate(testPodcast)
+                        .test()
+                        .assertValue { it is ValidationResult.Success }
+            }
+        }
+
         context("url validation failed") {
 
             beforeEach {
@@ -44,6 +53,15 @@ class PodcastValidatorSpec {
             }
         }
 
+        context("owner does not have email address") {
+
+            it("emits result as failure") {
+                env.validator.validate(testPodcast.copy(people = testPodcast.people.copy(ownerIds = listOf(Environment.PERSON_WITHOUT_EMAIL.id))))
+                        .test()
+                        .assertValue { it is ValidationResult.Failure }
+            }
+        }
+
         context("description length is too big") {
 
             it("emits result as failure") {
@@ -55,9 +73,15 @@ class PodcastValidatorSpec {
     }
 
     private class Environment {
+
+        companion object {
+            val PERSON = testPerson
+            val PERSON_WITHOUT_EMAIL = testPerson.copy(id = "person without email", email = null)
+        }
+
         val urlValidator = TestUrlValidator()
 
-        val validator = PodcastValidator(urlValidator, listOf(testPerson))
+        val validator = PodcastValidator(urlValidator, listOf(PERSON, PERSON_WITHOUT_EMAIL))
     }
 
     private class TestUrlValidator : Validator<String> {


### PR DESCRIPTION
Apparently it is mandatory. Pretty sure it is possible to publish without it, but it is better have it to be safe.

> Include the email address of the owner in a nested <itunes:email> tag and the name of the owner in a nested <itunes:name> tag.
> Note: The <itunes:owner> tag information is for administrative communication about the podcast and isn’t displayed in Apple Podcasts.