### PR TITLE
Remove podcast XML keywords support.

### DIFF
--- a/sample/podcast.yaml
+++ b/sample/podcast.yaml
@@ -13,12 +13,6 @@ language:
 explicit: false
 category: Technology
 subcategory: Software How-To
-keywords:
-  - android
-  - androiddev
-  - context
-  - development
-  - software
 url: "https://github.com/artem-zinnatullin/TheContext-Podcast"
 artworkUrl: "https://raw.githubusercontent.com/artem-zinnatullin/TheContext-Podcast/master/logo.png"
 feedUrl: "https://raw.githubusercontent.com/artem-zinnatullin/TheContext-Podcast/master/feed.rss"

--- a/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
@@ -40,7 +40,6 @@ interface PodcastXmlFormatter {
                             "explicit" to if (podcast.explicit) "yes" else "no",
                             "category" to podcast.category,
                             "subcategory" to podcast.subcategory,
-                            "keywords" to podcast.keywords.joinToString(separator = ","),
                             "owners" to podcast.people.ownerIds.map { people.find(it) }.map { mapOf("name" to it.name, "email" to it.email) },
                             "authors" to podcast.people.authorIds.map { people.find(it) }.map { mapOf("name" to it.name) },
                             "build_date" to LocalDate.now().toRfc2822(),

--- a/src/main/kotlin/io/thecontext/ci/value/Podcast.kt
+++ b/src/main/kotlin/io/thecontext/ci/value/Podcast.kt
@@ -28,9 +28,6 @@ data class Podcast(
         @JsonProperty("subcategory")
         val subcategory: String,
 
-        @JsonProperty("keywords")
-        val keywords: List<String>,
-
         @JsonProperty("url")
         val url: String,
 

--- a/src/main/resources/podcast.xml.mustache
+++ b/src/main/resources/podcast.xml.mustache
@@ -13,7 +13,6 @@
     <itunes:category text="{{category}}">
       <itunes:category text="{{subcategory}}"/>
     </itunes:category>
-    <itunes:keywords>{{keywords}}</itunes:keywords>
     {{#owners}}
     <itunes:owner>
       <itunes:name>{{name}}</itunes:name>

--- a/src/test/kotlin/io/thecontext/ci/Data.kt
+++ b/src/test/kotlin/io/thecontext/ci/Data.kt
@@ -28,7 +28,6 @@ val testPodcast = Podcast(
         explicit = false,
         category = "Podcast category",
         subcategory = "Podcast subcategory",
-        keywords = listOf("keyword"),
         url = "localhost/podcast",
         artworkUrl = "localhost/podcast/artwork",
         feedUrl = "localhost/podcast/feed"

--- a/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
@@ -66,8 +66,6 @@ class YamlReaderSpec {
                     explicit: ${podcast.explicit}
                     category: ${podcast.category}
                     subcategory: ${podcast.subcategory}
-                    keywords:
-                        - ${podcast.keywords.first()}
                     url: ${podcast.url}
                     artworkUrl: ${podcast.artworkUrl}
                     feedUrl: ${podcast.feedUrl}

--- a/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
@@ -36,7 +36,6 @@ class PodcastXmlFormatterSpec {
                         <itunes:category text="${podcast.category}">
                           <itunes:category text="${podcast.subcategory}"/>
                         </itunes:category>
-                        <itunes:keywords>${podcast.keywords.joinToString(separator = ",")}</itunes:keywords>
                         <itunes:owner>
                           <itunes:name>${people[0].name}</itunes:name>
                           <itunes:email>${people[0].email}</itunes:email>


### PR DESCRIPTION
Was trying to find them in Apple and Google specs and failed. Apparently deprecated and unused for years now. Welp.

Sources:

* https://www.reddit.com/r/podcasts/comments/2triav/does_anyone_know_about_itunes_keywords/
* https://discussions.apple.com/thread/8232215