### PR TITLE
Replace Atom authors with iTunes authors in podcast XML.

### DIFF
--- a/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
@@ -41,7 +41,7 @@ interface PodcastXmlFormatter {
                             "category" to podcast.category,
                             "subcategory" to podcast.subcategory,
                             "owners" to podcast.people.ownerIds.map { people.find(it) }.map { mapOf("name" to it.name, "email" to it.email) },
-                            "authors" to podcast.people.authorIds.map { people.find(it) }.map { mapOf("name" to it.name) },
+                            "authors" to podcast.people.authorIds.map { people.find(it).name }.joinToString(),
                             "build_date" to LocalDate.now().toRfc2822(),
                             "episodes" to preparedEpisodes.map { (episode, episodeMarkdown) ->
                                 mapOf(

--- a/src/main/resources/podcast.xml.mustache
+++ b/src/main/resources/podcast.xml.mustache
@@ -19,11 +19,7 @@
       <itunes:email>{{email}}</itunes:email>
     </itunes:owner>
     {{/owners}}
-    {{#authors}}
-    <atom:author>
-      <atom:name>{{name}}</atom:name>
-    </atom:author>
-    {{/authors}}
+    <itunes:author>{{authors}}</itunes:author>
     {{#episodes}}
     <item>
       <title>{{title}}</title>

--- a/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
@@ -44,12 +44,7 @@ class PodcastXmlFormatterSpec {
                           <itunes:name>${people[1].name}</itunes:name>
                           <itunes:email>${people[1].email}</itunes:email>
                         </itunes:owner>
-                        <atom:author>
-                          <atom:name>${people[0].name}</atom:name>
-                        </atom:author>
-                        <atom:author>
-                          <atom:name>${people[1].name}</atom:name>
-                        </atom:author>
+                        <itunes:author>${people.map { it.name }.joinToString()}</itunes:author>
                         <item>
                           <title>${episode.title}</title>
                           <description>${episode.description}</description>


### PR DESCRIPTION
Another nail in `atom` coffin. Turns out nobody uses Atom tags (like, at all). Neither Apple or Google spec mention them. On other hand, `itunes:author` is being shown as-is on iTunes page and various search results (including Pocket Casts and Google Podcasts).

[ATP as an example](https://itunes.apple.com/us/podcast/accidental-tech-podcast/id617416468). Done via:

```xml
<itunes:author>Marco Arment, Casey Liss, John Siracusa</itunes:author>
```
