### PR TITLE
Remove remaining Atom attributes.

### DIFF
--- a/sample/podcast.yaml
+++ b/sample/podcast.yaml
@@ -15,4 +15,3 @@ category: Technology
 subcategory: Software How-To
 url: "https://github.com/artem-zinnatullin/TheContext-Podcast"
 artworkUrl: "https://raw.githubusercontent.com/artem-zinnatullin/TheContext-Podcast/master/logo.png"
-feedUrl: "https://raw.githubusercontent.com/artem-zinnatullin/TheContext-Podcast/master/feed.rss"

--- a/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
@@ -33,7 +33,6 @@ interface PodcastXmlFormatter {
                             "title" to podcast.title,
                             "language" to "${podcast.language.code.toLowerCase()}-${podcast.language.regionCode.toLowerCase()}",
                             "url" to podcast.url,
-                            "feed_url" to podcast.feedUrl,
                             "subtitle" to podcast.subtitle,
                             "description" to podcast.description,
                             "artwork_url" to podcast.artworkUrl,

--- a/src/main/kotlin/io/thecontext/ci/validation/PodcastValidator.kt
+++ b/src/main/kotlin/io/thecontext/ci/validation/PodcastValidator.kt
@@ -14,7 +14,7 @@ class PodcastValidator(
     }
 
     override fun validate(value: Podcast): Single<ValidationResult> {
-        val urlResults = listOf(value.url, value.artworkUrl, value.feedUrl).map {
+        val urlResults = listOf(value.url, value.artworkUrl).map {
             urlValidator.validate(it)
         }
 

--- a/src/main/kotlin/io/thecontext/ci/value/Podcast.kt
+++ b/src/main/kotlin/io/thecontext/ci/value/Podcast.kt
@@ -32,10 +32,7 @@ data class Podcast(
         val url: String,
 
         @JsonProperty("artworkUrl")
-        val artworkUrl: String,
-
-        @JsonProperty("feedUrl")
-        val feedUrl: String
+        val artworkUrl: String
 
 ) {
 

--- a/src/main/resources/podcast.xml.mustache
+++ b/src/main/resources/podcast.xml.mustache
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>{{title}}</title>
     <description>{{description}}</description>
     <language>{{language}}</language>
     <link>{{url}}</link>
     <lastBuildDate>{{build_date}}</lastBuildDate>
-    <atom:link rel="self" type="application/rss+xml" href="{{feed_url}}"/>
     <itunes:subtitle>{{subtitle}}</itunes:subtitle>
     <itunes:image href="{{artwork_url}}"/>
     <itunes:explicit>{{explicit}}</itunes:explicit>
@@ -28,7 +27,6 @@
       <guid>{{id}}</guid>
       <link>{{url}}</link>
       <enclosure url="{{file_url}}" length="{{file_length}}" type="audio/mpeg"/>
-      <atom:link rel="replies" type="text/html" href="{{discussion_url}}"/>
       <itunes:duration>{{duration}}</itunes:duration>
       <content:encoded>
         <![CDATA[

--- a/src/test/kotlin/io/thecontext/ci/Data.kt
+++ b/src/test/kotlin/io/thecontext/ci/Data.kt
@@ -29,8 +29,7 @@ val testPodcast = Podcast(
         category = "Podcast category",
         subcategory = "Podcast subcategory",
         url = "localhost/podcast",
-        artworkUrl = "localhost/podcast/artwork",
-        feedUrl = "localhost/podcast/feed"
+        artworkUrl = "localhost/podcast/artwork"
 )
 
 val testEpisode = Episode(

--- a/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
@@ -68,7 +68,6 @@ class YamlReaderSpec {
                     subcategory: ${podcast.subcategory}
                     url: ${podcast.url}
                     artworkUrl: ${podcast.artworkUrl}
-                    feedUrl: ${podcast.feedUrl}
                     """
 
             beforeEach {

--- a/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
@@ -22,14 +22,13 @@ class PodcastXmlFormatterSpec {
             it("formats") {
                 val expected = """
                     <?xml version="1.0" encoding="utf-8"?>
-                    <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+                    <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/">
                       <channel>
                         <title>${podcast.title}</title>
                         <description>${podcast.description}</description>
                         <language>${podcast.language.code.toLowerCase()}-${podcast.language.regionCode.toLowerCase()}</language>
                         <link>${podcast.url}</link>
                         <lastBuildDate>${LocalDate.now().toRfc2822()}</lastBuildDate>
-                        <atom:link rel="self" type="application/rss+xml" href="${podcast.feedUrl}"/>
                         <itunes:subtitle>${podcast.subtitle}</itunes:subtitle>
                         <itunes:image href="${podcast.artworkUrl}"/>
                         <itunes:explicit>${if (podcast.explicit) "yes" else "no"}</itunes:explicit>
@@ -52,7 +51,6 @@ class PodcastXmlFormatterSpec {
                           <guid>${episode.id}</guid>
                           <link>${episode.url}</link>
                           <enclosure url="${episode.file.url}" length="${episode.file.length}" type="audio/mpeg"/>
-                          <atom:link rel="replies" type="text/html" href="${episode.discussionUrl}"/>
                           <itunes:duration>${episode.duration}</itunes:duration>
                           <content:encoded>
                             <![CDATA[


### PR DESCRIPTION
It is really weird why the current feed even has them. As far as I can see in specs both of them are not even remotely used. The same goes to real-life podcast players. I can only presume that it was done to comply the general RSS feed spec but it is not the same as the podcast feed spec.