### PR TITLE
Remove podcast subtitle support.

### DIFF
--- a/sample/podcast.yaml
+++ b/sample/podcast.yaml
@@ -1,5 +1,4 @@
 title: "The Context #androiddev"
-subtitle: New Android Developers Podcast
 description: The Context is a podcast about Android Development
 peopleIds:
   owners:

--- a/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
@@ -33,7 +33,6 @@ interface PodcastXmlFormatter {
                             "title" to podcast.title,
                             "language" to "${podcast.language.code.toLowerCase()}-${podcast.language.regionCode.toLowerCase()}",
                             "url" to podcast.url,
-                            "subtitle" to podcast.subtitle,
                             "description" to podcast.description,
                             "artwork_url" to podcast.artworkUrl,
                             "explicit" to if (podcast.explicit) "yes" else "no",

--- a/src/main/kotlin/io/thecontext/ci/value/Podcast.kt
+++ b/src/main/kotlin/io/thecontext/ci/value/Podcast.kt
@@ -7,9 +7,6 @@ data class Podcast(
         @JsonProperty("title")
         val title: String,
 
-        @JsonProperty("subtitle")
-        val subtitle: String,
-
         @JsonProperty("description")
         val description: String,
 

--- a/src/main/resources/podcast.xml.mustache
+++ b/src/main/resources/podcast.xml.mustache
@@ -6,7 +6,6 @@
     <language>{{language}}</language>
     <link>{{url}}</link>
     <lastBuildDate>{{build_date}}</lastBuildDate>
-    <itunes:subtitle>{{subtitle}}</itunes:subtitle>
     <itunes:image href="{{artwork_url}}"/>
     <itunes:explicit>{{explicit}}</itunes:explicit>
     <itunes:category text="{{category}}">

--- a/src/test/kotlin/io/thecontext/ci/Data.kt
+++ b/src/test/kotlin/io/thecontext/ci/Data.kt
@@ -15,7 +15,6 @@ val testPerson = Person(
 
 val testPodcast = Podcast(
         title = "Podcast Title",
-        subtitle = "Podcast Subtitle",
         description = "Podcast Description",
         people = Podcast.People(
                 ownerIds = listOf(testPerson.id, testPerson.id),

--- a/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
@@ -51,7 +51,6 @@ class YamlReaderSpec {
             val podcastYaml =
                     """
                     title: ${podcast.title}
-                    subtitle: ${podcast.subtitle}
                     description: ${podcast.description}
                     peopleIds:
                         owners:

--- a/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
@@ -29,7 +29,6 @@ class PodcastXmlFormatterSpec {
                         <language>${podcast.language.code.toLowerCase()}-${podcast.language.regionCode.toLowerCase()}</language>
                         <link>${podcast.url}</link>
                         <lastBuildDate>${LocalDate.now().toRfc2822()}</lastBuildDate>
-                        <itunes:subtitle>${podcast.subtitle}</itunes:subtitle>
                         <itunes:image href="${podcast.artworkUrl}"/>
                         <itunes:explicit>${if (podcast.explicit) "yes" else "no"}</itunes:explicit>
                         <itunes:category text="${podcast.category}">


### PR DESCRIPTION
Fortunately or not the only place I saw it used is Overcast web UI. Google spec doesn’t even mention it. At the same time, a lot of feeds alias it to `itunes:summary` and `description` but seems like `description` is more than enough.