### PR TITLE
Move episode number and part formatting from YAML.

### DIFF
--- a/src/main/kotlin/io/thecontext/ci/output/EpisodeMarkdownFormatter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/EpisodeMarkdownFormatter.kt
@@ -23,7 +23,6 @@ interface EpisodeMarkdownFormatter {
         override fun format(podcast: Podcast, episode: Episode, people: List<Person>) = Single
                 .fromCallable {
                     val contents = mapOf(
-                            "title" to episode.title,
                             "podcast_url" to podcast.url,
                             "discussion_url" to episode.discussionUrl,
                             "description" to episode.description,

--- a/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/PodcastXmlFormatter.kt
@@ -43,9 +43,15 @@ interface PodcastXmlFormatter {
                             "authors" to podcast.people.authorIds.map { people.find(it).name }.joinToString(),
                             "build_date" to LocalDate.now().toRfc2822(),
                             "episodes" to preparedEpisodes.map { (episode, episodeMarkdown) ->
+                                val episodeTitle = if (episode.part == null) {
+                                    "Episode ${episode.number}: ${episode.title}"
+                                } else {
+                                    "Episode ${episode.number}, Part ${episode.part}: ${episode.title}"
+                                }
+
                                 mapOf(
                                         "id" to episode.id,
-                                        "title" to episode.title,
+                                        "title" to episodeTitle,
                                         "description" to episode.description,
                                         "date" to episode.date.toDate().toRfc2822(),
                                         "file_url" to episode.file.url,

--- a/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
+++ b/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
@@ -60,6 +60,14 @@ class EpisodeValidator(
             }
         }
 
+        val partResult = Single.fromCallable {
+            if (value.part != null && value.part < 0) {
+                ValidationResult.Failure("$episodeIdentifierForError: Episode part is negative.")
+            } else {
+                ValidationResult.Success
+            }
+        }
+
         val dateResult = Single.fromCallable {
             try {
                 value.date.toDate()
@@ -87,7 +95,7 @@ class EpisodeValidator(
         }
 
         return Single
-                .merge(urlResults + peopleResults + listOf(idResult, numberResult, dateResult, fileLengthResult, descriptionResult))
+                .merge(urlResults + peopleResults + listOf(idResult, numberResult, partResult, dateResult, fileLengthResult, descriptionResult))
                 .toList()
                 .map { it.merge() }
     }

--- a/src/main/kotlin/io/thecontext/ci/value/Episode.kt
+++ b/src/main/kotlin/io/thecontext/ci/value/Episode.kt
@@ -11,6 +11,9 @@ data class Episode(
 
         @JsonProperty("number")
         val number: Int,
+
+        @JsonProperty("part")
+        val part: Int?,
   
         @JsonProperty("title")
         val title: String,

--- a/src/main/resources/episode.md.mustache
+++ b/src/main/resources/episode.md.mustache
@@ -1,9 +1,7 @@
-# {{title}}
+{{&description}}
 
 * [How to listen and subscribe]({{podcast_url}})
 * [Discussion after the episode]({{discussion_url}})
-
-{{&description}}
 
 ## Guests
 

--- a/src/test/kotlin/io/thecontext/ci/Data.kt
+++ b/src/test/kotlin/io/thecontext/ci/Data.kt
@@ -34,6 +34,7 @@ val testPodcast = Podcast(
 val testEpisode = Episode(
         id = "thecontext/episode/42",
         number = 42,
+        part = 2,
         title = "Episode Title",
         description = "Episode Description",
         people = Episode.People(

--- a/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
@@ -82,6 +82,7 @@ class YamlReaderSpec {
                     """
                     id: ${episode.id}
                     number: ${episode.number}
+                    part: ${episode.part}
                     title: ${episode.title}
                     description: ${episode.description}
                     date: ${episode.date}

--- a/src/test/kotlin/io/thecontext/ci/output/EpisodeMarkdownFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/EpisodeMarkdownFormatterSpec.kt
@@ -25,12 +25,10 @@ class EpisodeMarkdownFormatterSpec {
 
             it("formats") {
                 val expected = """
-                    # ${episode.title}
+                    ${episode.description}
 
                     * [How to listen and subscribe](${podcast.url})
                     * [Discussion after the episode](${episode.discussionUrl})
-
-                    ${episode.description}
 
                     ## Guests
 

--- a/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/PodcastXmlFormatterSpec.kt
@@ -40,7 +40,7 @@ class PodcastXmlFormatterSpec {
                         </itunes:owner>
                         <itunes:author>${people.map { it.name }.joinToString()}</itunes:author>
                         <item>
-                          <title>${episode.title}</title>
+                          <title>Episode ${episode.number}, Part ${episode.part}: ${episode.title}</title>
                           <description>${episode.description}</description>
                           <pubDate>${episode.date.toDate().toRfc2822()}</pubDate>
                           <guid>${episode.id}</guid>

--- a/src/test/kotlin/io/thecontext/ci/validation/EpisodeValidatorSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/validation/EpisodeValidatorSpec.kt
@@ -28,6 +28,24 @@ class EpisodeValidatorSpec {
             }
         }
 
+        context("number is negative") {
+
+            it("emits result as failure") {
+                env.validator.validate(testEpisode.copy(number = -1))
+                        .test()
+                        .assertValue { it is ValidationResult.Failure }
+            }
+        }
+
+        context("part is negative") {
+
+            it("emits result as failure") {
+                env.validator.validate(testEpisode.copy(part = -1))
+                        .test()
+                        .assertValue { it is ValidationResult.Failure }
+            }
+        }
+
         context("url validation failed") {
 
             beforeEach {


### PR DESCRIPTION
Makes it harder to screw up the consistency accidentally. Not the biggest fan of doing this in code instead of templates but Mustache is limited this way (i. e. no conditionals). Let’s address this when someone other than us tries to use it.