### PR TITLE
Change people links to be customizable.

### DIFF
--- a/sample/people.yaml
+++ b/sample/people.yaml
@@ -1,15 +1,23 @@
-- id: artem.zinnatullin
-  name: Artem Zinnatullin
-  twitter: artem_zin
-  github: artem-zinnatullin
-  website: "https://artemzin.com"
-- id: hannes.dorfmann
-  name: Hannes Dorfmann
-  twitter: sockeqwe
-  github: sockeqwe
-  website: "http://hannesdorfmann.com"
-- id: artur.dryomov
-  name: Artur Dryomov
-  twitter: arturdryomov
-  github: ming13
-  website: "https://arturdryomov.online"
+- id: "artem.zinnatullin"
+  name: "Artem Zinnatullin"
+  twitter: "artem_zin"
+  github: "artem-zinnatullin"
+  links:
+    - name: "blog"
+      url: "https://artemzin.com"
+
+- id: "hannes.dorfmann"
+  name: "Hannes Dorfmann"
+  twitter: "sockeqwe"
+  github: "sockeqwe"
+  links:
+    - name: "blog"
+      url: "http://hannesdorfmann.com"
+
+- id: "artur.dryomov"
+  name: "Artur Dryomov"
+  twitter: "arturdryomov"
+  github: "ming13"
+  links:
+    - name: "blog"
+      url: "https://arturdryomov.online"

--- a/src/main/kotlin/io/thecontext/ci/output/EpisodeMarkdownFormatter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/EpisodeMarkdownFormatter.kt
@@ -44,11 +44,7 @@ interface EpisodeMarkdownFormatter {
                 formatLink("GitHub", "https://github.com/$it")
             }
 
-            val siteLink = person.site?.let {
-                formatLink("website", it)
-            }
-
-            val links = listOfNotNull(twitterLink, githubLink, siteLink)
+            val links = listOfNotNull(twitterLink, githubLink) + person.links.map { formatLink(it.name, it.url) }
 
             return if (links.isEmpty()) {
                 person.name

--- a/src/main/kotlin/io/thecontext/ci/output/WebsiteFormatter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/WebsiteFormatter.kt
@@ -41,11 +41,7 @@ interface WebsiteFormatter {
                 formatLink("GitHub", "https://github.com/$it")
             }
 
-            val siteLink = person.site?.let {
-                formatLink("website", it)
-            }
-
-            val links = listOfNotNull(twitterLink, githubLink, siteLink)
+            val links = listOfNotNull(twitterLink, githubLink) + person.links.map { formatLink(it.name, it.url) }
 
             return if (links.isEmpty()) {
                 person.name

--- a/src/main/kotlin/io/thecontext/ci/value/Person.kt
+++ b/src/main/kotlin/io/thecontext/ci/value/Person.kt
@@ -19,9 +19,21 @@ data class Person(
         @JsonProperty("github")
         val github: String?,
 
-        @JsonProperty("website")
-        val site: String?
+        @JsonProperty("links")
+        val links: List<Link>
 
-)
+) {
+
+    data class Link(
+
+            @JsonProperty("name")
+            val name: String,
+
+            @JsonProperty("url")
+            val url: String
+
+    )
+
+}
 
 fun List<Person>.find(id: String) = this.find { it.id == id } ?: throw IllegalArgumentException("Person [$id] is not available.")

--- a/src/test/kotlin/io/thecontext/ci/Data.kt
+++ b/src/test/kotlin/io/thecontext/ci/Data.kt
@@ -10,7 +10,10 @@ val testPerson = Person(
         email = "person@mail.com",
         twitter = "Twitter ID",
         github = "GitHub ID",
-        site = "localhost"
+        links = listOf(Person.Link(
+                name = "blog",
+                url = "https://localhost"
+        ))
 )
 
 val testPodcast = Podcast(

--- a/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
@@ -33,7 +33,9 @@ class YamlReaderSpec {
                       email: ${person.email}
                       twitter: ${person.twitter}
                       github: ${person.github}
-                      website: ${person.site}
+                      links:
+                          - name: ${person.links.first().name}
+                            url: ${person.links.first().url}
                     """
 
             beforeEach {

--- a/src/test/kotlin/io/thecontext/ci/output/EpisodeMarkdownFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/EpisodeMarkdownFormatterSpec.kt
@@ -32,13 +32,13 @@ class EpisodeMarkdownFormatterSpec {
 
                     ## Guests
 
-                    * ${people[0].name}: [Twitter](https://twitter.com/${people[0].twitter}), [GitHub](https://github.com/${people[0].github}), [website](${people[0].site})
-                    * ${people[1].name}: [Twitter](https://twitter.com/${people[1].twitter}), [GitHub](https://github.com/${people[1].github}), [website](${people[1].site})
+                    * ${people[0].name}: [Twitter](https://twitter.com/${people[0].twitter}), [GitHub](https://github.com/${people[0].github}), [${people[0].links.first().name}](${people[0].links.first().url})
+                    * ${people[1].name}: [Twitter](https://twitter.com/${people[1].twitter}), [GitHub](https://github.com/${people[1].github}), [${people[1].links.first().name}](${people[1].links.first().url})
 
                     ## Hosts
 
-                    * ${people[0].name}: [Twitter](https://twitter.com/${people[0].twitter}), [GitHub](https://github.com/${people[0].github}), [website](${people[0].site})
-                    * ${people[1].name}: [Twitter](https://twitter.com/${people[1].twitter}), [GitHub](https://github.com/${people[1].github}), [website](${people[1].site})
+                    * ${people[0].name}: [Twitter](https://twitter.com/${people[0].twitter}), [GitHub](https://github.com/${people[0].github}), [${people[0].links.first().name}](${people[0].links.first().url})
+                    * ${people[1].name}: [Twitter](https://twitter.com/${people[1].twitter}), [GitHub](https://github.com/${people[1].github}), [${people[1].links.first().name}](${people[1].links.first().url})
 
                     ## Notes
 

--- a/src/test/kotlin/io/thecontext/ci/output/WebsiteFormatterSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/WebsiteFormatterSpec.kt
@@ -7,9 +7,7 @@ import io.reactivex.schedulers.Schedulers
 import io.thecontext.ci.testEpisode
 import io.thecontext.ci.testPerson
 import io.thecontext.ci.testPodcast
-import io.thecontext.ci.value.Person
 import org.junit.runner.RunWith
-import kotlin.math.exp
 
 @RunWith(Spectrum::class)
 class WebsiteFormatterSpec {
@@ -23,7 +21,6 @@ class WebsiteFormatterSpec {
                 id = "host1",
                 github = "github1",
                 name = "Person 1",
-                site = "person1.com",
                 twitter = "person1"
         )
 
@@ -31,7 +28,6 @@ class WebsiteFormatterSpec {
                 id = "host2",
                 github = "github2",
                 name = "Person 2",
-                site = "person2.com",
                 twitter = "person2"
         )
 
@@ -39,7 +35,6 @@ class WebsiteFormatterSpec {
                 id = "guest1",
                 github = "github3",
                 name = "Person 3",
-                site = "person3.com",
                 twitter = "person3"
         )
 
@@ -47,7 +42,6 @@ class WebsiteFormatterSpec {
                 id = "guest2",
                 github = "github4",
                 name = "Person 4",
-                site = "person4.com",
                 twitter = "person4"
         )
 
@@ -74,13 +68,13 @@ class WebsiteFormatterSpec {
 
                     ## Guests
 
-                    * ${guest1.name}: [Twitter](https://twitter.com/${guest1.twitter}), [GitHub](https://github.com/${guest1.github}), [website](${guest1.site})
-                    * ${guest2.name}: [Twitter](https://twitter.com/${guest2.twitter}), [GitHub](https://github.com/${guest2.github}), [website](${guest2.site})
+                    * ${guest1.name}: [Twitter](https://twitter.com/${guest1.twitter}), [GitHub](https://github.com/${guest1.github}), [${guest1.links.first().name}](${guest1.links.first().url})
+                    * ${guest2.name}: [Twitter](https://twitter.com/${guest2.twitter}), [GitHub](https://github.com/${guest2.github}), [${guest2.links.first().name}](${guest2.links.first().url})
 
                     ## Hosts
 
-                    * ${host1.name}: [Twitter](https://twitter.com/${host1.twitter}), [GitHub](https://github.com/${host1.github}), [website](${host1.site})
-                    * ${host2.name}: [Twitter](https://twitter.com/${host2.twitter}), [GitHub](https://github.com/${host2.github}), [website](${host2.site})
+                    * ${host1.name}: [Twitter](https://twitter.com/${host1.twitter}), [GitHub](https://github.com/${host1.github}), [${host1.links.first().name}](${host1.links.first().url})
+                    * ${host2.name}: [Twitter](https://twitter.com/${host2.twitter}), [GitHub](https://github.com/${host2.github}), [${host2.links.first().name}](${host2.links.first().url})
 
                     ## Notes
 


### PR DESCRIPTION
Closes #16.

I think it fits really well with potential non-English podcasts using the tool. We take care of known websites (Twitter and GitHub) for now, otherwise its users call to name it.