### PR TITLE
Change files search to ignore hidden directories.

### DIFF
--- a/src/main/kotlin/io/thecontext/ci/input/InputFilesLocator.kt
+++ b/src/main/kotlin/io/thecontext/ci/input/InputFilesLocator.kt
@@ -45,7 +45,7 @@ interface InputFilesLocator {
                     val episodes = directory
                             .walk()
                             .maxDepth(1)
-                            .filter { it.isDirectory && it != directory }
+                            .filter { it.isDirectory && !it.isHidden && it != directory }
                             .map { File(it, FileNames.EPISODE) to File(it, FileNames.EPISODE_NOTES) }
                             .toMap()
 


### PR DESCRIPTION
Can be an issue if all files are located in the root of a Git repository since we’ll try to treat the `.git` directory as an episode one.