### PR TITLE
Change feed episode template.

### DIFF
--- a/src/main/resources/episode.md.mustache
+++ b/src/main/resources/episode.md.mustache
@@ -1,20 +1,19 @@
 {{&description}}
 
-* [How to listen and subscribe]({{podcast_url}})
-* [Discussion after the episode]({{discussion_url}})
+{{&notes}}
 
-## Guests
+**Guests**
 
 {{#guests}}
 * {{&guest}}
 {{/guests}}
 
-## Hosts
+**Hosts**
 
 {{#hosts}}
 * {{&host}}
 {{/hosts}}
 
-## Notes
+**Discussion**
 
-{{&notes}}
+[Give us your opinion on the episode]({{discussion_url}})!


### PR DESCRIPTION
* The `content:encoded` section is very limited (`android.text.Html` limited). Headers are definitely out of the picture.
* Moved notes on the top to preserve readers interest: short description → broader description → people → discussion. Honestly saying it is the most sane variant. Plus, OG Artem did it this way from the very beginning.