### PR TITLE
Use rssFeedDirectory instead of shotNotesDirectory or rss file location

### DIFF
--- a/src/main/kotlin/io/thecontext/ci/output/OutputWriter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/OutputWriter.kt
@@ -44,9 +44,9 @@ interface OutputWriter {
             val feed = podcastXmlFormatter.format(podcast, episodes, people)
                     .flatMap { podcastXml ->
                         Single.fromCallable {
-                            showNotesDirectory.mkdirs()
+                            rssFeedDirectory.mkdirs()
 
-                            textWriter.write(File(showNotesDirectory, FileNames.FEED), podcastXml)
+                            textWriter.write(File(rssFeedDirectory, FileNames.FEED), podcastXml)
                         }
                     }
                     .map { Unit }


### PR DESCRIPTION
Seems like a copy & paste error. It should use `rssFeedDirectory` instead of `shotNotesDirectory` as the destination folder for the rss file.