### PR TITLE
Update CommonMark 0.11.0 → 0.12.1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 apply plugin: "kotlin"

--- a/versions.gradle
+++ b/versions.gradle
@@ -4,7 +4,7 @@ ext.versions = [
         kotlin    : "1.3.11",
         rxjava    : "2.2.4",
         jackson   : "2.9.8",
-        commonmark: "0.11.0",
+        commonmark: "0.12.1",
         okhttp    : "3.12.1",
         mustache  : "0.9.5",
 


### PR DESCRIPTION
[Changes](https://github.com/atlassian/commonmark-java/releases/tag/commonmark-parent-0.12.1).

For some reason the update wasn’t visible when using `jcenter`.