### PR TITLE
Change episode date to be time.

### DIFF
--- a/sample/11-rxjava-2/episode.yaml
+++ b/sample/11-rxjava-2/episode.yaml
@@ -1,7 +1,7 @@
 number: 11
 title: "Migration to RxJava 2 with Artur Dryomov from Juno"
 description: "We’ve talked to Artur about Juno’s way to migrate their Android Riders App from RxJava 1 to RxJava 2."
-date: "2017-05-15"
+time: "2017-05-15T10:15"
 duration: "00:52:46"
 peopleIds:
   hosts:

--- a/src/main/kotlin/io/thecontext/ci/Time.kt
+++ b/src/main/kotlin/io/thecontext/ci/Time.kt
@@ -1,10 +1,25 @@
 package io.thecontext.ci
 
-import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
-fun String.toDate(): LocalDate = LocalDate.parse(this, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+interface Time {
 
-fun LocalDate.toRfc2822(): String = atStartOfDay(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z"))
+    fun current(): LocalDateTime
 
+    fun parseIso(time: String): LocalDateTime
+    fun formatRfc2822(time: LocalDateTime): String
+
+    class Impl : Time {
+
+        companion object {
+            private val FORMATTER_RFC_2822 = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z")
+        }
+
+        override fun current() = LocalDateTime.now()
+
+        override fun parseIso(time: String) = LocalDateTime.parse(time, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        override fun formatRfc2822(time: LocalDateTime) = time.atZone(ZoneId.of("UTC")).format(FORMATTER_RFC_2822)
+    }
+}

--- a/src/main/kotlin/io/thecontext/ci/context/Context.kt
+++ b/src/main/kotlin/io/thecontext/ci/context/Context.kt
@@ -2,13 +2,18 @@ package io.thecontext.ci.context
 
 import io.reactivex.Scheduler
 import io.reactivex.schedulers.Schedulers
+import io.thecontext.ci.Time
 
 interface Context {
 
     val ioScheduler: Scheduler
 
+    val time: Time
+
     class Impl : Context {
 
         override val ioScheduler by lazy { Schedulers.io() }
+
+        override val time by lazy { Time.Impl() }
     }
 }

--- a/src/main/kotlin/io/thecontext/ci/context/OutputContext.kt
+++ b/src/main/kotlin/io/thecontext/ci/context/OutputContext.kt
@@ -16,7 +16,7 @@ interface OutputContext : Context {
         private val textWriter by lazy { TextWriter.Impl() }
 
         private val feedEpisodeRenderer by lazy { FeedEpisodeRenderer.Impl(mustacheRenderer, ioScheduler) }
-        private val feedRenderer by lazy { FeedRenderer.Impl(feedEpisodeRenderer, markdownRenderer, mustacheRenderer, ioScheduler) }
+        private val feedRenderer by lazy { FeedRenderer.Impl(feedEpisodeRenderer, markdownRenderer, mustacheRenderer, time, ioScheduler) }
         private val websiteRenderer by lazy { WebsiteRenderer.Impl(mustacheRenderer, ioScheduler) }
 
         override val outputWriter by lazy { OutputWriter.Impl(feedRenderer, feedEpisodeRenderer, websiteRenderer, textWriter, ioScheduler) }

--- a/src/main/kotlin/io/thecontext/ci/context/ValidationContext.kt
+++ b/src/main/kotlin/io/thecontext/ci/context/ValidationContext.kt
@@ -17,7 +17,7 @@ interface ValidationContext : Context {
         private val urlValidator by lazy { UrlValidator(ioScheduler) }
 
         override val podcastValidator by lazy { PodcastValidator(urlValidator, people) }
-        override val episodeValidator by lazy { EpisodeValidator(urlValidator, people) }
+        override val episodeValidator by lazy { EpisodeValidator(urlValidator, people, time) }
         override val episodesValidator by lazy { EpisodeListValidator(ioScheduler) }
     }
 }

--- a/src/main/kotlin/io/thecontext/ci/output/OutputWriter.kt
+++ b/src/main/kotlin/io/thecontext/ci/output/OutputWriter.kt
@@ -61,7 +61,7 @@ interface OutputWriter {
                         websiteDirectory.mkdirs()
                         val operations = it.map { (episode, episodeWebsiteMarkdown) ->
                             Single.fromCallable {
-                                textWriter.write(File(websiteDirectory, "${episode.date}-${episode.slug}.md"), episodeWebsiteMarkdown)
+                                textWriter.write(File(websiteDirectory, "${episode.slug}.md"), episodeWebsiteMarkdown)
                             }
                         }
 

--- a/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
+++ b/src/main/kotlin/io/thecontext/ci/validation/EpisodeValidator.kt
@@ -1,14 +1,15 @@
 package io.thecontext.ci.validation
 
 import io.reactivex.Single
-import io.thecontext.ci.toDate
+import io.thecontext.ci.Time
 import io.thecontext.ci.value.Episode
 import io.thecontext.ci.value.Person
 import java.time.format.DateTimeParseException
 
 class EpisodeValidator(
         private val urlValidator: Validator<String>,
-        private val people: List<Person>
+        private val people: List<Person>,
+        private val time: Time
 ) : Validator<Episode> {
 
     companion object {
@@ -70,7 +71,7 @@ class EpisodeValidator(
 
         val dateResult = Single.fromCallable {
             try {
-                value.date.toDate()
+                time.parseIso(value.time)
 
                 ValidationResult.Success
             } catch (e: DateTimeParseException) {

--- a/src/main/kotlin/io/thecontext/ci/value/Episode.kt
+++ b/src/main/kotlin/io/thecontext/ci/value/Episode.kt
@@ -30,8 +30,8 @@ data class Episode(
         @JsonProperty("discussionUrl")
         val discussionUrl: String,
 
-        @JsonProperty("date")
-        val date: String,
+        @JsonProperty("time")
+        val time: String,
 
         @JsonProperty("duration")
         val duration: String,

--- a/src/test/kotlin/io/thecontext/ci/Data.kt
+++ b/src/test/kotlin/io/thecontext/ci/Data.kt
@@ -46,7 +46,7 @@ val testEpisode = Episode(
         ),
         url = "localhost/episode",
         discussionUrl = "localhost/discussion",
-        date = "2000-12-30",
+        time = "2000-12-30T10:15",
         duration = "100:00",
         file = Episode.File(
                 url = "localhost/episode/file",

--- a/src/test/kotlin/io/thecontext/ci/TestTime.kt
+++ b/src/test/kotlin/io/thecontext/ci/TestTime.kt
@@ -1,0 +1,14 @@
+package io.thecontext.ci
+
+import java.time.LocalDateTime
+
+class TestTime : Time {
+    var currentResult = LocalDateTime.MIN
+
+    var formatRfc2822Result = "2000-01-01T00:00"
+
+    override fun current() = currentResult
+
+    override fun parseIso(time: String) = Time.Impl().parseIso(time)
+    override fun formatRfc2822(time: LocalDateTime) = formatRfc2822Result
+}

--- a/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/input/YamlReaderSpec.kt
@@ -87,7 +87,7 @@ class YamlReaderSpec {
                     part: ${episode.part}
                     title: ${episode.title}
                     description: ${episode.description}
-                    date: ${episode.date}
+                    time: ${episode.time}
                     duration: ${episode.duration}
                     peopleIds:
                         hosts:

--- a/src/test/kotlin/io/thecontext/ci/output/feed/FeedRendererSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/output/feed/FeedRendererSpec.kt
@@ -8,7 +8,6 @@ import io.thecontext.ci.*
 import io.thecontext.ci.output.HtmlRenderer
 import io.thecontext.ci.output.TemplateRenderer
 import org.junit.runner.RunWith
-import java.time.LocalDate
 
 @RunWith(Spectrum::class)
 class FeedRendererSpec {
@@ -18,9 +17,9 @@ class FeedRendererSpec {
         val podcast = testPodcast
         val people = listOf(testPerson, testPerson)
 
-        val episode1 = testEpisode.copy(number = 1, part = null, date = "2000-01-01")
-        val episode2Part1 = testEpisode.copy(number = 2, part = 1, date = "2000-01-02")
-        val episode2Part2 = testEpisode.copy(number = 2, part = 2, date = "2000-01-03")
+        val episode1 = testEpisode.copy(number = 1, part = null, time = "2000-01-01T10:15")
+        val episode2Part1 = testEpisode.copy(number = 2, part = 1, time = "2000-01-02T10:15")
+        val episode2Part2 = testEpisode.copy(number = 2, part = 2, time = "2000-01-03T10:15")
 
         context("regular podcast") {
 
@@ -33,7 +32,7 @@ class FeedRendererSpec {
                         <description>${podcast.description}</description>
                         <language>${podcast.language.code.toLowerCase()}-${podcast.language.regionCode.toLowerCase()}</language>
                         <link>${podcast.url}</link>
-                        <lastBuildDate>${LocalDate.now().toRfc2822()}</lastBuildDate>
+                        <lastBuildDate>${env.time.formatRfc2822Result}</lastBuildDate>
                         <itunes:image href="${podcast.artworkUrl}"/>
                         <itunes:explicit>${if (podcast.explicit) "yes" else "no"}</itunes:explicit>
                         <itunes:category text="${podcast.category}">
@@ -47,7 +46,7 @@ class FeedRendererSpec {
                         <item>
                           <title>Episode ${episode1.number}: ${episode1.title}</title>
                           <description>${episode1.description}</description>
-                          <pubDate>${episode1.date.toDate().toRfc2822()}</pubDate>
+                          <pubDate>${env.time.formatRfc2822Result}</pubDate>
                           <guid>${episode1.id}</guid>
                           <link>${episode1.url}</link>
                           <enclosure url="${episode1.file.url}" length="${episode1.file.length}" type="audio/mpeg"/>
@@ -61,7 +60,7 @@ class FeedRendererSpec {
                         <item>
                           <title>Episode ${episode2Part1.number}, Part ${episode2Part1.part}: ${episode2Part1.title}</title>
                           <description>${episode2Part1.description}</description>
-                          <pubDate>${episode2Part1.date.toDate().toRfc2822()}</pubDate>
+                          <pubDate>${env.time.formatRfc2822Result}</pubDate>
                           <guid>${episode2Part1.id}</guid>
                           <link>${episode2Part1.url}</link>
                           <enclosure url="${episode2Part1.file.url}" length="${episode2Part1.file.length}" type="audio/mpeg"/>
@@ -75,7 +74,7 @@ class FeedRendererSpec {
                         <item>
                           <title>Episode ${episode2Part2.number}, Part ${episode2Part2.part}: ${episode2Part2.title}</title>
                           <description>${episode2Part2.description}</description>
-                          <pubDate>${episode2Part2.date.toDate().toRfc2822()}</pubDate>
+                          <pubDate>${env.time.formatRfc2822Result}</pubDate>
                           <guid>${episode2Part2.id}</guid>
                           <link>${episode2Part2.url}</link>
                           <enclosure url="${episode2Part2.file.url}" length="${episode2Part2.file.length}" type="audio/mpeg"/>
@@ -101,11 +100,13 @@ class FeedRendererSpec {
 
     class Environment {
         val markdownRenderer = TestHtmlRenderer()
+        val time = TestTime()
 
         val renderer = FeedRenderer.Impl(
                 feedEpisodeRenderer = FeedEpisodeRenderer.Impl(TemplateRenderer.Impl(), Schedulers.trampoline()),
                 htmlRenderer = markdownRenderer,
                 templateRenderer = TemplateRenderer.Impl(),
+                time = time,
                 ioScheduler = Schedulers.trampoline()
         )
     }

--- a/src/test/kotlin/io/thecontext/ci/validation/EpisodeValidatorSpec.kt
+++ b/src/test/kotlin/io/thecontext/ci/validation/EpisodeValidatorSpec.kt
@@ -3,6 +3,7 @@ package io.thecontext.ci.validation
 import com.greghaskins.spectrum.Spectrum
 import com.greghaskins.spectrum.dsl.specification.Specification.*
 import io.reactivex.Single
+import io.thecontext.ci.Time
 import io.thecontext.ci.memoized
 import io.thecontext.ci.testEpisode
 import io.thecontext.ci.testPerson
@@ -80,7 +81,7 @@ class EpisodeValidatorSpec {
         context("date is in wrong format") {
 
             it("emits result as failure") {
-                env.validator.validate(testEpisode.copy(date = "ZERO"))
+                env.validator.validate(testEpisode.copy(time = "ZERO"))
                         .test()
                         .assertValue { it is ValidationResult.Failure }
             }
@@ -108,7 +109,7 @@ class EpisodeValidatorSpec {
     private class Environment {
         val urlValidator = TestUrlValidator()
 
-        val validator = EpisodeValidator(urlValidator, listOf(testPerson))
+        val validator = EpisodeValidator(urlValidator, listOf(testPerson), Time.Impl())
     }
 
     private class TestUrlValidator : Validator<String> {


### PR DESCRIPTION
There might be multiple episodes per day, especially parted ones. Podcast players proceed to put episodes with the same date and without time in a random order which is of course undesirable.

Probably going to replace renderer tests with integration ones. It becomes more and more obvious that either we should duplicate formatting logic in tests or put more and more boilerplate. File comparison probably would work better.